### PR TITLE
Fix the site description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,10 +6,7 @@ url: https://siskin.im
 title: Siskin IM by Tigase, Inc.
 email: support@tigase.net
 author: Tigase, Inc.
-description: > # "Write an awesome description for your new site here.
-  You can edit this line in _config.yml. It will appear in your document
-  head meta (for Google search results) and in your feed.xml site
-  description.
+description: 'Lightweight and powerful XMPP client for iPhone and iPad.'
 copyright: 'Copyright &copy; 2019 Tigase, Inc. All Rights Reserved.'
 credits: 'Credits: Landing Page is a free to use, open source Bootstrap theme created by <a href="http://startbootstrap.com/">Start Bootstrap</a>.'
 


### PR DESCRIPTION
Looks like the site used a template description from somewhere that caused the website to look like this in Google Search results:
![The picture with the default site description](https://storage.tdem.in/s/GSjtSEJqnA4HiWL/preview)