### PR TITLE
Fix link to Tigase's mastodon profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ social:
   - title:
     superclass: b
     class: mastodon
-    url: https://mastodon.technology/@tigase
+    url: https://fosstodon.org/@tigase
   - title: github
     superclass: b
     class: github


### PR DESCRIPTION
Used to be on mastodon.technology but is now on fosstodon.org.

See also: https://github.com/tigase/beagle-im-website/pull/1/commits